### PR TITLE
Fix for grunt maxBuffer exceeded

### DIFF
--- a/tasks/build/installNpmDeps.js
+++ b/tasks/build/installNpmDeps.js
@@ -6,7 +6,8 @@ module.exports = function (grunt) {
     grunt.file.mkdir('build/kibana/node_modules');
 
     exec('npm install  --production --no-optional', {
-      cwd: grunt.config.process('<%= root %>/build/kibana')
+      cwd: grunt.config.process('<%= root %>/build/kibana'),
+      maxBuffer: 500 * 1024
     }, this.async());
   });
 };


### PR DESCRIPTION
When run with the default std buffer size we get `stderr maxBuffer exceeded Use --force to continue`. The fix is to increase the maxbuffer size.
